### PR TITLE
Fix issue with binary path inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags 
   env ${OPTS} CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w \
   -X github.com/openfaas-incubator/mqtt-connector/pkg/version.Release=${VERSION} \
   -X github.com/openfaas-incubator/mqtt-connector/pkg/version.SHA=${GIT_COMMIT}" \
-  -a -installsuffix cgo -o inlets-operator . && \
+  -a -installsuffix cgo -o connector . && \
   addgroup --system app && \
   adduser --system --ingroup app app && \
   mkdir /scratch-tmp
@@ -35,7 +35,7 @@ FROM scratch
 COPY --from=builder /etc/passwd /etc/group /etc/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder --chown=app:app /scratch-tmp /tmp/
-COPY --from=builder /go/src/github.com/openfaas-incubator/mqtt-connector/inlets-operator .
+COPY --from=builder /go/src/github.com/openfaas-incubator/mqtt-connector/connector /usr/bin/connector
 
 USER app
 

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,29 @@
 .PHONY: build push manifest test verify-codegen charts
 TAG?=latest
+NAMESPACE?=openfaas
 
 # docker manifest command will work with Docker CLI 18.03 or newer
 # but for now it's still experimental feature so we need to enable that
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 build:
-	docker build -t openfaas/mqtt-connector:$(TAG)-amd64 . -f Dockerfile
-	docker build --build-arg OPTS="GOARCH=arm64" -t openfaas/mqtt-connector:$(TAG)-arm64 . -f Dockerfile
-	docker build --build-arg OPTS="GOARCH=arm GOARM=6" -t openfaas/mqtt-connector:$(TAG)-armhf . -f Dockerfile
+	docker build -t $(NAMESPACE)/mqtt-connector:$(TAG)-amd64 . -f Dockerfile
+	docker build --build-arg OPTS="GOARCH=arm64" -t $(NAMESPACE)/mqtt-connector:$(TAG)-arm64 . -f Dockerfile
+	docker build --build-arg OPTS="GOARCH=arm GOARM=6" -t $(NAMESPACE)/mqtt-connector:$(TAG)-armhf . -f Dockerfile
 
 push:
-	docker push openfaas/mqtt-connector:$(TAG)-amd64
-	docker push openfaas/mqtt-connector:$(TAG)-arm64
-	docker push openfaas/mqtt-connector:$(TAG)-armhf
+	docker push $(NAMESPACE)/mqtt-connector:$(TAG)-amd64
+	docker push $(NAMESPACE)/mqtt-connector:$(TAG)-arm64
+	docker push $(NAMESPACE)/mqtt-connector:$(TAG)-armhf
 
 manifest:
-	docker manifest create --amend openfaas/mqtt-connector:$(TAG) \
-		openfaas/mqtt-connector:$(TAG)-amd64 \
-		openfaas/mqtt-connector:$(TAG)-arm64 \
-		openfaas/mqtt-connector:$(TAG)-armhf
-	docker manifest annotate openfaas/mqtt-connector:$(TAG) openfaas/mqtt-connector:$(TAG)-arm64 --os linux --arch arm64
-	docker manifest annotate openfaas/mqtt-connector:$(TAG) openfaas/mqtt-connector:$(TAG)-armhf --os linux --arch arm --variant v6
-	docker manifest push -p openfaas/mqtt-connector:$(TAG)
+	docker manifest create --amend $(NAMESPACE)/mqtt-connector:$(TAG) \
+		$(NAMESPACE)/mqtt-connector:$(TAG)-amd64 \
+		$(NAMESPACE)/mqtt-connector:$(TAG)-arm64 \
+		$(NAMESPACE)/mqtt-connector:$(TAG)-armhf
+	docker manifest annotate $(NAMESPACE)/mqtt-connector:$(TAG) $(NAMESPACE)/mqtt-connector:$(TAG)-arm64 --os linux --arch arm64
+	docker manifest annotate $(NAMESPACE)/mqtt-connector:$(TAG) $(NAMESPACE)/mqtt-connector:$(TAG)-armhf --os linux --arch arm --variant v6
+	docker manifest push -p $(NAMESPACE)/mqtt-connector:$(TAG)
 
 test:
 	go test ./...


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

I was trying to deploy with the helm chart present in the repo but it was failing.  
```
LAST SEEN   TYPE      REASON              OBJECT                                 MESSAGE
55m         Normal    Pulled              pod/mqtt-connector-66fdcdcc49-d6rk4    Container image "openfaas/mqtt-connector:0.3.0" already present on machine
15m         Warning   BackOff             pod/mqtt-connector-66fdcdcc49-d6rk4    Back-off restarting failed container
11m         Normal    ScalingReplicaSet   deployment/mqtt-connector              Scaled up replica set mqtt-connector-6df98dcb56 to 1
11m         Normal    SuccessfulCreate    replicaset/mqtt-connector-6df98dcb56   Created pod: mqtt-connector-6df98dcb56-2lrj8
<unknown>   Normal    Scheduled           pod/mqtt-connector-6df98dcb56-2lrj8    Successfully assigned openfaas/mqtt-connector-6df98dcb56-2lrj8 to k3d-k3s-default-server
11m         Normal    Pulling             pod/mqtt-connector-6df98dcb56-2lrj8    Pulling image "viveksyngh/mqtt-connector:0.3.0"
11m         Normal    Pulled              pod/mqtt-connector-6df98dcb56-2lrj8    Successfully pulled image "viveksyngh/mqtt-connector:0.3.0"
10m         Normal    Pulled              pod/mqtt-connector-6df98dcb56-2lrj8    Container image "viveksyngh/mqtt-connector:0.3.0" already present on machine
10m         Normal    Created             pod/mqtt-connector-6df98dcb56-2lrj8    Created container connector
10m         Warning   Failed              pod/mqtt-connector-6df98dcb56-2lrj8    Error: failed to create containerd task: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/usr/bin/connector\": stat /usr/bin/connector: no such file or directory": unknown
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on my local computer.

```
19s         Normal    ScalingReplicaSet   deployment/mqtt-connector              Scaled up replica set mqtt-connector-5978b44579 to 1
19s         Normal    SuccessfulCreate    replicaset/mqtt-connector-5978b44579   Created pod: mqtt-connector-5978b44579-f9qzk
<unknown>   Normal    Scheduled           pod/mqtt-connector-5978b44579-f9qzk    Successfully assigned openfaas/mqtt-connector-5978b44579-f9qzk to k3d-k3s-default-server
18s         Normal    Pulling             pod/mqtt-connector-5978b44579-f9qzk    Pulling image "viveksyngh/mqtt-connector:0.3.1"
8s          Normal    Pulled              pod/mqtt-connector-5978b44579-f9qzk    Successfully pulled image "viveksyngh/mqtt-connector:0.3.1"
8s          Normal    Created             pod/mqtt-connector-5978b44579-f9qzk    Created container connector
8s          Normal    Started             pod/mqtt-connector-5978b44579-f9qzk    Started container connector
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
